### PR TITLE
Updated README to reflect correct usage of GorgeousHeader

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ npm i @freakycoder/react-native-header-view
 ## Gorgeous Header Usage
 
 ```jsx
-import { Gorgeous } from "@freakycoder/react-native-header-view";
+import { GorgeousHeader } from "@freakycoder/react-native-header-view";
 
-<Gorgeous onChangeText={(text) => console.log(text)} />;
+<GorgeousHeader onChangeText={(text) => console.log(text)} />;
 ```
 
 ## Apple Header Usage


### PR DESCRIPTION
The header previously said to import `GorgeousHeader` as just `Gorgeous`, but this was causing an invalid import. Updated the README to reflect correct usage.